### PR TITLE
Fixed bug where server would crash because user has null values in profile

### DIFF
--- a/packages/backend/src/database/entities.ts
+++ b/packages/backend/src/database/entities.ts
@@ -32,13 +32,13 @@ export class User {
 	readonly password: string;
 
 	@Column({ type: "text", nullable: true })
-	first_name: string;
+	first_name: string | undefined;
 
 	@Column({ type: "text", nullable: true })
-	last_name: string;
+	last_name: string | undefined;
 
 	@Column({ type: "text", nullable: true })
-	bio: string;
+	bio: string | undefined;
 
 	@Column({ type: "enum", enum: Gender, default: Gender.kOther })
 	gender: Gender;
@@ -50,7 +50,7 @@ export class User {
 	sexual_orientation: SexualOrientation;
 
 	@Column({ type: 'timestamp', nullable: true })
-	birthday: Date;
+	birthday: Date | undefined;
 
 	@Column({ type: "int", default: 0 })
 	height_mm: number;

--- a/packages/backend/src/dtos/dtos.entity.ts
+++ b/packages/backend/src/dtos/dtos.entity.ts
@@ -47,17 +47,17 @@ export class GetUserResponse {
 	/*
 	 * The first name of the user.
 	 */
-	first_name: string;
+	first_name: string | undefined;
 
 	/*
 	 * The last name of the user.
 	 */
-	last_name: string;
+	last_name: string | undefined;
 
 	/*
 	 * The biography of the user.
 	 */
-	bio: string;
+	bio: string | undefined;
 
 	/*
 	 * The gender of the user.
@@ -68,7 +68,7 @@ export class GetUserResponse {
 	/*
 	 * The pronouns of the user.
 	 */
-	pronouns: string;
+	pronouns: string | undefined;
 
 	/*
 	 * The sexual orientation of the user.
@@ -79,17 +79,17 @@ export class GetUserResponse {
 	/*
 	 * Birthdate of the user in ms since epoch
 	 */
-	birthday_ms_since_epoch: number;
+	birthday_ms_since_epoch: number | undefined;
 
 	/*
 	 * The height of the user in millimeters
 	 */
-	height_mm: number;
+	height_mm: number | undefined;
 
 	/*
 	 * The occupation of the user
 	 */
-	occupation: string;
+	occupation: string | undefined;
 }
 
 export class FindMatchingUsersResponse {

--- a/packages/backend/src/user/user.controller.ts
+++ b/packages/backend/src/user/user.controller.ts
@@ -28,7 +28,7 @@ export class UserController {
 			gender: user.gender,
 			pronouns: user.pronouns,
 			sexual_orientation: user.sexual_orientation,
-			birthday_ms_since_epoch: user.birthday.getTime(),
+			birthday_ms_since_epoch: user.birthday?.getTime(),
 			height_mm: user.height_mm,
 			occupation: user.occupation,
 		};
@@ -66,7 +66,7 @@ export class UserController {
 			gender: updated_user.gender,
 			pronouns: updated_user.pronouns,
 			sexual_orientation: updated_user.sexual_orientation,
-			birthday_ms_since_epoch: updated_user.birthday.getTime(),
+			birthday_ms_since_epoch: updated_user.birthday?.getTime(),
 			height_mm: updated_user.height_mm,
 			occupation: updated_user.occupation,
 		};


### PR DESCRIPTION
Trying to query any users profile who had any null value at all would cause a server crash. This changes it so that the server simply returns null in those fields.

It also changes the type in the database entity so that I don't make type errors like that in the future I hope.