### PR TITLE
fixing "no more profiles" alignment

### DIFF
--- a/packages/frontend/src/components/CardStack.js
+++ b/packages/frontend/src/components/CardStack.js
@@ -335,12 +335,7 @@ const CardStack = () => {
               </AnimatePresence>
             </motion.div>
           ) : (
-            <motion.div
-              style={styles.emptyState}
-              initial={{ opacity: 0, scale: 0.8 }}
-              animate={{ opacity: 1, scale: 1 }}
-              transition={{ type: "spring", damping: 15 }}
-            >
+            <div style={styles.emptyState}>
               <p style={styles.emptyText}>No more profiles to show!</p>
               <button
                 style={styles.resetButton}
@@ -354,7 +349,7 @@ const CardStack = () => {
               >
                 Find More Matches
               </button>
-            </motion.div>
+            </div>
           )}
         </AnimatePresence>
       </div>


### PR DESCRIPTION
When user has swiped through all possible users, "no more profiles" shows up. This fix ensures the pop-up is in the middle. 
