### PR TITLE
fix: set home/base route to login

### DIFF
--- a/packages/frontend/src/App.js
+++ b/packages/frontend/src/App.js
@@ -39,6 +39,7 @@ function App() {
     <div style={styles.pageContainer}>
       <div style={styles.contentWrapper}>
         <Routes>
+          <Route path="/" element={<Login />} />
           <Route path="/login" element={<Login />} />
           <Route path="/profile" element={<Profile />} />
           <Route path="/userprofile/:guid" element={<UserProfile />} />


### PR DESCRIPTION
Fix:
- created new default/home/root route to login page (no need for landing atm)

Testing:
- tested manually, checks out

Nits:
- if we make a splash/home/info page we can route to that instead in the future